### PR TITLE
Using kiosk mode to hide Grafana nav and header instead of using CSS

### DIFF
--- a/omp_server/promemonitor/grafana_url.py
+++ b/omp_server/promemonitor/grafana_url.py
@@ -157,4 +157,5 @@ def explain_url(explain_info, is_service=None):
             instance_info['monitor_url'] = grafana_url + \
                 url_dict.get('node', 'nohosts') + f"?var-node={service_ip}"
             instance_info['log_url'] = None
+        instance_info['monitor_url'] = instance_info['monitor_url'] + "&kiosk"
     return explain_info

--- a/omp_web/src/components/OmpIframe/index.js
+++ b/omp_web/src/components/OmpIframe/index.js
@@ -18,8 +18,6 @@ const OmpIframe = ({ showIframe, setShowIframe, iframeSrc }) => {
           style={{
             width:`calc(100% + 70px)`,
             position: "absolute",
-            top: showIframe?.isLog?-55:-106,
-            left: -66,
           }}
           src={showIframe.src}
           width="100%"


### PR DESCRIPTION
Add `&kiosk` in Grafana share URL will hide nav and header, so we shouldn't use CSS.